### PR TITLE
fix: исправить директорию homebrew с Casks на Formula

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -70,4 +70,4 @@ homebrew_casks:
   - repository:
       owner: jtprogru
       name: homebrew-tap
-    directory: Casks
+    directory: Formula


### PR DESCRIPTION
Исправлена ошибка в настройке goreleaser, из-за которой новый релиз и тег не добавлялись в homebrew-tap. Директория Formula является правильной для формул homebrew.